### PR TITLE
refactor(navigation): Implement ScrollController for improved navigation and conditional app bar

### DIFF
--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -9,54 +9,82 @@ import '../widgets/contact_section.dart';
 import '../widgets/footer_widget.dart';
 import '../utils/navigation_service.dart';
 
-class HomePage extends StatelessWidget {
+class HomePage extends StatefulWidget {
   const HomePage({super.key});
+
+  @override
+  State<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
+  final ScrollController _scrollController = ScrollController();
+  bool _showAppBar = false;
+
+  @override
+  void initState() {
+    super.initState();
+    NavigationService.setScrollController(_scrollController);
+    
+    _scrollController.addListener(() {
+      final shouldShow = _scrollController.offset > 200; // Show after scrolling 200px
+      if (shouldShow != _showAppBar) {
+        setState(() {
+          _showAppBar = shouldShow;
+        });
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: Colors.white,
-      body: NestedScrollView(
-        headerSliverBuilder: (context, innerBoxIsScrolled) => [
-          const PortfolioSliverAppBar(),
-        ],
-        body: CustomScrollView(
-          slivers: [
+      appBar: _showAppBar ? const PortfolioAppBar() : null,
+      body: SingleChildScrollView(
+        controller: _scrollController,
+        child: Column(
+          children: [
             // Hero Section (no key needed as it's always at top)
-            const SliverToBoxAdapter(child: HeroSection()),
+            const HeroSection(),
             
             // About Section
-            SliverToBoxAdapter(
+            Container(
               key: NavigationService.getSectionKey('About'),
               child: const AboutSection(),
             ),
             
             // Skills Section
-            SliverToBoxAdapter(
+            Container(
               key: NavigationService.getSectionKey('Skills'),
               child: const SkillsSection(),
             ),
             
             // Projects Section
-            SliverToBoxAdapter(
+            Container(
               key: NavigationService.getSectionKey('Projects'),
               child: const ProjectsSection(),
             ),
             
             // Experience Section
-            SliverToBoxAdapter(
+            Container(
               key: NavigationService.getSectionKey('Experience'),
               child: const ExperienceSection(),
             ),
             
             // Contact Section
-            SliverToBoxAdapter(
+            Container(
               key: NavigationService.getSectionKey('Contact'),
               child: const ContactSection(),
             ),
             
             // Footer
-            const SliverToBoxAdapter(child: FooterWidget()),
+            const FooterWidget(),
           ],
         ),
       ),

--- a/lib/utils/navigation_service.dart
+++ b/lib/utils/navigation_service.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 
 class NavigationService {
+  static ScrollController? _scrollController;
+  
   static final Map<String, GlobalKey> _sectionKeys = {
     'About': GlobalKey(),
     'Skills': GlobalKey(),
@@ -9,6 +11,10 @@ class NavigationService {
     'Contact': GlobalKey(),
   };
 
+  static void setScrollController(ScrollController controller) {
+    _scrollController = controller;
+  }
+
   static GlobalKey getSectionKey(String section) {
     return _sectionKeys[section] ?? GlobalKey();
   }
@@ -16,13 +22,19 @@ class NavigationService {
   static void scrollToSection(String section) {
     final key = _sectionKeys[section];
     final context = key?.currentContext;
-    if (context != null) {
-      Scrollable.ensureVisible(
-        context,
-        duration: const Duration(milliseconds: 800),
-        curve: Curves.easeInOut,
-        alignment: 0.0, // Scroll to top of the section
-      );
+    
+    if (context != null && _scrollController != null) {
+      final RenderObject? renderObject = context.findRenderObject();
+      if (renderObject is RenderBox) {
+        final position = renderObject.localToGlobal(Offset.zero);
+        final offset = position.dy + _scrollController!.offset - 80; // 80 for AppBar height
+        
+        _scrollController!.animateTo(
+          offset.clamp(0.0, _scrollController!.position.maxScrollExtent),
+          duration: const Duration(milliseconds: 800),
+          curve: Curves.easeInOut,
+        );
+      }
     }
   }
 }


### PR DESCRIPTION
### ✨ New Functionality
*   The main application app bar is now only displayed after the user scrolls down 200 pixels, providing a more immersive hero section experience.

### 🛠️ Refactoring & Architectural Changes
*   Converted `HomePage` from a `StatelessWidget` to a `StatefulWidget` to manage a `ScrollController` and app bar visibility state.
*   Replaced the `NestedScrollView` and `CustomScrollView` combination with a `SingleChildScrollView` backed by a `ScrollController` for simplified layout management and precise scroll control.
*   Updated `NavigationService` to accept and utilize the `ScrollController` from `HomePage` for programmatic scrolling.

### 🐛 Bug Fixes
*   Replaced `Scrollable.ensureVisible` with a manual offset calculation using `RenderBox` and `controller.animateTo`. This provides more reliable and accurate scrolling to sections.
*   The scroll-to calculation now includes an 80px offset to account for the app bar's height, preventing section headers from being obscured after navigation.