### PR TITLE
ci(workflows): Pin Flutter version to 3.35.1

### DIFF
--- a/.github/workflows/flutter-web.yml
+++ b/.github/workflows/flutter-web.yml
@@ -15,7 +15,8 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: 'stable'
+          flutter-version: '3.35.1'
+          channel: 'stable'
 
       - name: Install dependencies
         run: flutter pub get   # ensures packages are fetched before build


### PR DESCRIPTION
### 🧹 Maintenance & Chores

*   Pinned the Flutter version in the `flutter-web.yml` workflow to `3.35.1` to ensure build reproducibility.