### PR TITLE
ci(workflow): grant write permissions for contents

### DIFF
--- a/.github/workflows/flutter-web.yml
+++ b/.github/workflows/flutter-web.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ master ]   # change if your default branch is 'master'
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### 🧹 Maintenance & Chores

*   Added `permissions: contents: write` to the `flutter-web.yml` workflow.
*   This change is necessary to allow subsequent steps, such as deploying to GitHub Pages, to have the required permissions to push to the repository.